### PR TITLE
Return err on failure instead of using panic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Versions are parsed from strings like so:
     semver.FromString("1.9.0-beta1")
     // and so on...
 
+If the version parse fails it then the library will call panic(). If you prefer to simply return the error as the second
+argument then use:
+
+    semver.New("1.2.3")
+    semver.New("1.9.0-beta")
+
+The New function will return (*Version, error).
+
 This gives you a `Version` struct that you can then interact with and compare:
 
     v1 = semver.FromString("1.2.3")
@@ -21,6 +29,14 @@ This gives you a `Version` struct that you can then interact with and compare:
     v1.NotEqual(v2)           // true
     v1.LessThanOrEqual(v2)    // true
     v2.GreaterThanOrEqual(v1) // true
+    v1.String()               // 1.2.3
+
+Or using the New function:
+
+    v1, err = semver.FromString("1.2.3")
+    if err != nil {
+      // handle the error
+    }
     v1.String()               // 1.2.3
 
 You can also do pessimistic comparisons [like RubyGems](http://www.devalot.com/articles/2012/04/gem-versions.html):

--- a/semver.go
+++ b/semver.go
@@ -3,6 +3,7 @@
 package semver
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 )
@@ -17,11 +18,11 @@ type Version struct {
 }
 
 // Parse a Version struct from a version string like "1.2.4".
-func FromString(versionString string) *Version {
+func FromString(versionString string) (*Version, error) {
 	pieces := strings.Split(versionString, ".")
 
 	if len(pieces) != 3 {
-		panic("Malformed version (too short or too long).")
+		return nil, errors.New("semver: Malformed version (too short or too long).")
 	}
 
 	version := new(Version)
@@ -36,7 +37,7 @@ func FromString(versionString string) *Version {
 	version.Build = build
 	version.Pre = pre
 
-	return version
+	return version, nil
 }
 
 func SplitLast(last *string, delimiter string) string {

--- a/semver.go
+++ b/semver.go
@@ -17,8 +17,10 @@ type Version struct {
 	Build string
 }
 
-// Parse a Version struct from a version string like "1.2.4".
-func FromString(versionString string) (*Version, error) {
+// Construct a new Version struct from a version string like "1.2.4".
+// If the version string cannot be parsed then this function will return
+// nil for the version and an error.
+func New(versionString string) (*Version, error) {
 	pieces := strings.Split(versionString, ".")
 
 	if len(pieces) != 3 {
@@ -38,6 +40,17 @@ func FromString(versionString string) (*Version, error) {
 	version.Pre = pre
 
 	return version, nil
+}
+
+// Parse a Version struct from a version string like "1.2.4".
+// If the version string cannot be parsed then this function will
+// panic.
+func FromString(versionString string) (version *Version, err error) {
+	version, err = New(versionString)
+	if err != nil {
+		panic("Malformed version (too short or too long).")
+	}
+	return
 }
 
 func SplitLast(last *string, delimiter string) string {

--- a/semver.go
+++ b/semver.go
@@ -45,8 +45,8 @@ func New(versionString string) (*Version, error) {
 // Parse a Version struct from a version string like "1.2.4".
 // If the version string cannot be parsed then this function will
 // panic.
-func FromString(versionString string) (version *Version, err error) {
-	version, err = New(versionString)
+func FromString(versionString string) (version *Version) {
+	version, err := New(versionString)
 	if err != nil {
 		panic("Malformed version (too short or too long).")
 	}

--- a/semver_test.go
+++ b/semver_test.go
@@ -17,8 +17,29 @@ type TestData struct {
 	BaselinePessimisticZeroPatch *Version
 }
 
+func GenerateTestVersion(v string) *Version {
+	ver, err := FromString(v)
+	if err != nil {
+
+	}
+	return ver
+}
+
 func GenerateTestVersions() *TestData {
-	return &TestData{FromString("1.2.3"), FromString("2.2.3"), FromString("1.4.3"), FromString("1.2.5"), FromString("1.2.5-beta1"), FromString("1.2.5-beta1+322"), FromString("1.2.4+322"), FromString("1.2.4+939"), FromString("1.2.5-beta4"), FromString("1.0.0"), FromString("1.2.0"), FromString("1.2.1")}
+	return &TestData{
+		GenerateTestVersion("1.2.3"),
+		GenerateTestVersion("2.2.3"),
+		GenerateTestVersion("1.4.3"),
+		GenerateTestVersion("1.2.5"),
+		GenerateTestVersion("1.2.5-beta1"),
+		GenerateTestVersion("1.2.5-beta1+322"),
+		GenerateTestVersion("1.2.4+322"),
+		GenerateTestVersion("1.2.4+939"),
+		GenerateTestVersion("1.2.5-beta4"),
+		GenerateTestVersion("1.0.0"),
+		GenerateTestVersion("1.2.0"),
+		GenerateTestVersion("1.2.1"),
+	}
 }
 
 func TestParse(t *testing.T) {
@@ -66,33 +87,25 @@ func TestParseBuildNoPre(t *testing.T) {
 }
 
 func TestParseFailTooLong(t *testing.T) {
-	defer func() {
-		s := recover()
+	_, err := FromString("1.2.3.4.5.6")
+	if err == nil {
+		t.Fatal("Didn't error on long input.")
+	}
 
-		if s == nil {
-			t.Fatal("Didn't panic on long input.")
-		}
-		if s.(string) != "Malformed version (too short or too long)." {
-			t.Fatal("Wrong panic: ", s)
-		}
-	}()
-
-	FromString("1.2.3.4.5.6")
+	if err.Error() != "semver: Malformed version (too short or too long)." {
+		t.Fatal("Wrong error: ", err)
+	}
 }
 
 func TestParseFailTooShort(t *testing.T) {
-	defer func() {
-		s := recover()
+	_, err := FromString("1.2")
+	if err == nil {
+		t.Fatal("Didn't error on short input.")
+	}
 
-		if s == nil {
-			t.Fatal("Didn't panic on short input.")
-		}
-		if s.(string) != "Malformed version (too short or too long)." {
-			t.Fatal("Wrong panic: ", s)
-		}
-	}()
-
-	FromString("1.2")
+	if err.Error() != "semver: Malformed version (too short or too long)." {
+		t.Fatal("Wrong error: ", err)
+	}
 }
 
 func TestCompareLessThan(t *testing.T) {

--- a/semver_test.go
+++ b/semver_test.go
@@ -1,6 +1,7 @@
 package semver
 
 import "testing"
+import "fmt"
 
 type TestData struct {
 	Baseline                     *Version
@@ -18,9 +19,9 @@ type TestData struct {
 }
 
 func GenerateTestVersion(v string) *Version {
-	ver, err := FromString(v)
+	ver, err := New(v)
 	if err != nil {
-
+		panic(fmt.Sprint("Failed to generate test version: ", err))
 	}
 	return ver
 }
@@ -87,7 +88,7 @@ func TestParseBuildNoPre(t *testing.T) {
 }
 
 func TestParseFailTooLong(t *testing.T) {
-	_, err := FromString("1.2.3.4.5.6")
+	_, err := New("1.2.3.4.5.6")
 	if err == nil {
 		t.Fatal("Didn't error on long input.")
 	}
@@ -98,7 +99,7 @@ func TestParseFailTooLong(t *testing.T) {
 }
 
 func TestParseFailTooShort(t *testing.T) {
-	_, err := FromString("1.2")
+	_, err := New("1.2")
 	if err == nil {
 		t.Fatal("Didn't error on short input.")
 	}
@@ -106,6 +107,36 @@ func TestParseFailTooShort(t *testing.T) {
 	if err.Error() != "semver: Malformed version (too short or too long)." {
 		t.Fatal("Wrong error: ", err)
 	}
+}
+
+func TestParseFailTooLongPanic(t *testing.T) {
+	defer func() {
+		s := recover()
+
+		if s == nil {
+			t.Fatal("Didn't panic on long input.")
+		}
+		if s.(string) != "Malformed version (too short or too long)." {
+			t.Fatal("Wrong panic: ", s)
+		}
+	}()
+
+	FromString("1.2.3.4.5.6")
+}
+
+func TestParseFailTooShortPanic(t *testing.T) {
+	defer func() {
+		s := recover()
+
+		if s == nil {
+			t.Fatal("Didn't panic on short input.")
+		}
+		if s.(string) != "Malformed version (too short or too long)." {
+			t.Fatal("Wrong panic: ", s)
+		}
+	}()
+
+	FromString("1.2")
 }
 
 func TestCompareLessThan(t *testing.T) {


### PR DESCRIPTION
Based recommendation from Effective Go (http://golang.org/doc/effective_go.html#errors) libraries should not panic but should return an error value on failure.

I've now left the FromString function alone and have added a New function that returns `*Version, err`
